### PR TITLE
Bugfix/restore repository head

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Prometheus exporter that collects statistics from your second brain.
 - [X] Make InfluxDB parameters configurable
 - [X] Major refactor
 - [X] Backfill data using git
-- [ ] Support private repositories (Maybe with Github's PAT?)
+- [X] Support private repositories (Maybe with Github's PAT?)
 - [ ] Handle InfluxDB async write errors (https://github.com/influxdata/influxdb-client-go?tab=readme-ov-file#reading-async-errors)
 - [ ] Grafana dashboard
 - [ ] Docker compose example

--- a/cmd/zettelkasten-exporter/main.go
+++ b/cmd/zettelkasten-exporter/main.go
@@ -49,6 +49,8 @@ func main() {
 
 	// Periodic collection loop
 	for {
+		slog.Info("Starting metrics collection")
+		start := time.Now()
 		err = zet.Ensure()
 		if err != nil {
 			slog.Error("Error ensuring that zettelkasten is ready", slog.Any("error", err))
@@ -61,5 +63,6 @@ func main() {
 			os.Exit(1)
 		}
 		time.Sleep(cfg.CollectionInterval)
+		slog.Info("Collected metrics", slog.Duration("duration", time.Since(start)))
 	}
 }

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -31,7 +31,7 @@ func NewCollector(ignorePatterns []string, storage storage.Storage) Collector {
 }
 
 func (c *Collector) CollectMetrics(root fs.FS, collectionTime time.Time) error {
-	slog.Info("Collecting metrics")
+	slog.Debug("Collecting metrics", slog.Time("collection_time", collectionTime))
 	start := time.Now()
 	collected, err := c.collectMetrics(root)
 	if err != nil {
@@ -41,7 +41,7 @@ func (c *Collector) CollectMetrics(root fs.FS, collectionTime time.Time) error {
 	for name, metric := range collected.Notes {
 		c.storage.WriteMetric(name, metric, collectionTime)
 	}
-	slog.Info("Collected metrics", slog.Duration("duration", time.Since(start)))
+	slog.Debug("Collected metrics", slog.Duration("duration", time.Since(start)))
 
 	return nil
 }


### PR DESCRIPTION
Now the head of the repository is correctly reset to the latest branch commit after walking the history. Previously, the repository was left checked out in the last walked commit.